### PR TITLE
Fix issue that prevents starting the app in development on Windows

### DIFF
--- a/dev.bat
+++ b/dev.bat
@@ -1,3 +1,2 @@
 @echo off
-set NODE_ENV=development
-npm run dev
+npx cross-env NODE_ENV=development tsx server/index.ts

--- a/dev.ps1
+++ b/dev.ps1
@@ -1,2 +1,1 @@
-$env:NODE_ENV = "development"
-npm run dev
+npx cross-env NODE_ENV=development tsx server/index.ts


### PR DESCRIPTION
Use cross-env to set NODE_ENV for Windows compatibility when running the dev script.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: e7ab66a9-b896-487d-9843-2a39db118741
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/7dc8b031-c217-41a2-8354-b3c73141d4bb/d5289647-b06b-43d3-b002-d840269e53b5.jpg